### PR TITLE
New strings + minor changes

### DIFF
--- a/assets/lang/sklmessages_pl_PL.properties
+++ b/assets/lang/sklmessages_pl_PL.properties
@@ -8,8 +8,10 @@ lang.code=pl_PL
 tab.news=Aktualno\u015bci
 tab.log=Dziennik launchera
 tab.output=Dziennik gry (%s)
-tab.crash=Raport awarii (%s)
+tab.crash=Raport crasha (%s)
 tab.loading=\u0141adowanie
+tab.loading.long=Strona \u0142aduje si\u0119 zbyt d\u0142ugo?
+tab.loading.refresh=Od\u015bwie\u017c
 
 sidebar.switch=Prze\u0142. u\u017cytk.
 sidebar.new=Nowy profil
@@ -38,7 +40,7 @@ game.status.playing=W grze...
 game.status.idle=Bezczynny
 
 game.output.open=Otw\u00f3rz okno konsoli
-game.output.lines=linii pokazano
+game.output.lines=widocznych linii
 
 game.conflict.title=Ostrze\u017cenie o zduplikowanej instancji
 game.conflict.header=Posiadasz ju\u017c uruchomion\u0105 instancj\u0119 Minecrafta.
@@ -82,6 +84,8 @@ editor.compatibility.tooltip=Skiny nie dzia\u0142aj\u0105 w tym trybie, ale niek
 
 settings.title=Ustawienia launchera
 settings.lang=J\u0119zyk
+settings.lang.help=Widzisz jakie\u015b b\u0142\u0119dy w t\u0142umaczeniu?
+settings.lang.link=Do\u0142\u0105cz do dru\u017cyny t\u0142umaczy!
 settings.token=Specjalny klucz dost\u0119pu
 settings.save=Zapisz
 settings.cancel=Anuluj

--- a/assets/lang/sklmessages_pl_PL.properties
+++ b/assets/lang/sklmessages_pl_PL.properties
@@ -84,7 +84,7 @@ editor.compatibility.tooltip=Skiny nie dzia\u0142aj\u0105 w tym trybie, ale niek
 
 settings.title=Ustawienia launchera
 settings.lang=J\u0119zyk
-settings.lang.help=Widzisz jakie\u015b b\u0142\u0119dy w t\u0142umaczeniu?
+settings.lang.help=Widzisz jakie\u015b b\u0142\u0119dy w t\u0142umaczeniu?\u0020
 settings.lang.link=Do\u0142\u0105cz do dru\u017cyny t\u0142umaczy!
 settings.token=Specjalny klucz dost\u0119pu
 settings.save=Zapisz


### PR DESCRIPTION
I've also changed the tab.crash string.
Reason: "Awaria" is not used really. Let's use "crash" - most people use this term instead.

game.output.lines changed
Reason: sounds better.