### PR TITLE
Some lesser improvements to the en-US lang file

### DIFF
--- a/assets/lang/sklmessages_en_US.properties
+++ b/assets/lang/sklmessages_en_US.properties
@@ -38,9 +38,9 @@ game.output.lines=Switch console to
 game.output.type.list=List
 game.output.type.text=Text
 
-game.conflict.title=Duplicate instance warning
+game.conflict.title=Duplicate Instance Warning
 game.conflict.header=You already have an instance of Minecraft running.
-game.conflict.text=If you launch another one in the same folder, they may clash and corrupt your saves. \nThis could cause many issues, in singleplayer or otherwise. We will not be responsible for anything that goes wrong. \nDo you want to start another instance of Minecraft, despite this? \nYou may solve this issue by launching the game in a different folder (see the "Edit Profile" button).
+game.conflict.text=If you launch another one in the same directory, they may clash and corrupt your saves. \nThis could cause many issues, in singleplayer or otherwise. We will not be responsible for anything that goes wrong. \nDo you want to start another instance of Minecraft, despite this? \nYou may solve this issue by launching the game in a different directory (see the "Edit Profile" button).
 
 login.username=Mojang Email Address
 login.username.offline=Username
@@ -62,7 +62,7 @@ editor.keep=Keep the launcher open
 editor.snap=Snapshots
 editor.snap.tooltip=Allow use of experimental development versions ("snapshots")
 editor.historical=Historical
-editor.historical.tooltip=Allow use of "Alpha" and "Beta" Minecraft versions (From 2010-2011)
+editor.historical.tooltip=Allow use of "Alpha" and "Beta" Minecraft versions (from 2010–2011)
 editor.version=Use version
 editor.latest=Use latest version
 editor.compatibility=Compatibility Mode
@@ -86,16 +86,17 @@ settings.lang.link=Help us translate!
 settings.theme.light=Light Theme
 settings.theme.dark=Dark Theme
 settings.token=Beta Access Token
-settings.alert.title=Information
+settings.alert.title=Required Restart
 settings.alert.text=You need to restart the launcher to apply changes.
 settings.cancel=Cancel
 settings.save=Save
 
-crash.sorry=Uhoh! It looks like the game has crashed. Sorry for the inconvenience :(
-crash.vanilla=Using magic and love, we\'ve managed to gather some details about the crash and we will investigate this as soon as we can. You can see the full report below.
+crash.sorry=Uhoh! It looks like the game has crashed. Sorry for the inconveniences :(
+crash.vanilla=Using magic and love, we\'ve managed to gather some details about the crash, and we will investigate this as soon as we can. You can see the full report below.
 crash.modded=We think your game may be modded, and as such we can\'t accept this crash report. However, if you do indeed use mods, please send this to the mod authors to take a look at.
 crash.open=Open report file
-crash.alert.title=Oops, your game crashed
+
+crash.alert.title=Oops! Your game has crashed
 crash.alert.text=But we found a possible solution to your problem. Do you want to check that now?
 crash.alert.button.ignore=Ignore
 crash.alert.button.open=Open website


### PR DESCRIPTION
**In this commit I did the following:**
- changed "folder" to "directory" for consistency with `editor.gamedir` string
- changed "Oops, your game crashed" to "Oops! Your game crashed" for consistency with `crash.sorry` string
- changed "Information" to "Required Restart" to increase usability of this statement
- other less important changes.

@skmedix Do you plan to add in the near future more strings, except these related to #67, into U.S. English lang file? I'm asking, because I plan to add the new strings into all lang files to make it easier for translators to work. So if you plan to add new strings, I'll wait with that.