### PR TITLE
Fixed some weird translations (different spech context in menu)

### DIFF
--- a/assets/launcher/lang/sklmessages_es_MX.properties
+++ b/assets/launcher/lang/sklmessages_es_MX.properties
@@ -75,8 +75,8 @@ login.label.username=Usuario
 login.dropdown.name=Sesiones activas
 login.button.play=Jugar
 login.button.logout=Cerrar session
-login.button.switch.offline=Modo offline (sin cuenta)
-login.button.switch.online=Modo Online (microsoft)
+login.button.switch.offline=Modo offline
+login.button.switch.online=Modo Online
 
 # Ajustes
 settings.header.general=General
@@ -112,6 +112,7 @@ manager.profile.menu.duplicate=Duplicar
 manager.profile.menu.delete=Eliminar
 
 manager.editor.header.title=Editar Instancia
+manager.editor.footer.button.save=Guardar
 manager.editor.option.name.name=Nombre de la Instancia
 manager.editor.option.name.placeholder=<Instancia sin nombre>
 manager.editor.option.version.name=Version
@@ -119,17 +120,16 @@ manager.editor.option.directory.name=Carpeta del juego
 manager.editor.option.directory.placeholder=<Carpeta por defecto>
 manager.editor.option.directory.info.label=Algunos mods (no siempre) necesitan ser instalados en la carpeta .minecraft. Para usar la carpeta .minecraft
 manager.editor.option.directory.info.link=Haz click aqui
-manager.editor.footer.button.save=Guardar
 
 manager.editor.button.more=Mas opciones
 manager.editor.option.memory.name=Memoria maxima (RAM)
 manager.editor.option.compatibility.name=Modo de compatibilidad
 manager.editor.option.compatibility.enabled=Activado
 manager.editor.option.visibility.name=Visibilidad del launcher
-manager.editor.option.visibility.hide=Esconder (hasta cerrar MC)
+manager.editor.option.visibility.hide=Esconder hasta cerrar MC
 manager.editor.option.visibility.close=Cerrar completamente
 manager.editor.option.visibility.keep=Mostrar launcher y la consola
-manager.editor.option.visibility.keep.info=NOTA: No apta para computadoras de bajos recursos
+manager.editor.option.visibility.keep.info=No apta para computadoras de bajos recursos
 manager.editor.option.jvmpath.name=Binarios de JAVA
 manager.editor.option.jvmpath.placeholder=Usar JAVA por defecto
 manager.editor.option.jvmargs.name=Argumentos JVM

--- a/assets/launcher/lang/sklmessages_es_MX.properties
+++ b/assets/launcher/lang/sklmessages_es_MX.properties
@@ -6,17 +6,17 @@ general.support=Apoyanos en Patreon
 general.discord=Unete a nuestro Discord
 general.notready=¡Esta funcion aun no esta lista!
 
-tab.news=Actualizaciones
+tab.news=Novedades
 tab.log=Cambios en el Launcher
 tab.output=Consola del juego (%s)
 tab.crash=Reporte de error (%s)
 
 # Sidebar
-sidebar.label.logged=Accediste como
+sidebar.label.logged=Usuario activo
 sidebar.label.player=Jugador
 sidebar.button.switch=Cambiar usuario
-sidebar.button.settings=Ajustes del launcher
-sidebar.button.manager=Ajustes de la Instancia
+sidebar.button.settings=Ajustes del Launcher
+sidebar.button.manager=Instancias
 sidebar.label.loading=Cargando propiedades
 sidebar.menu.item.edit=Editar Instancia
 sidebar.menu.item.duplicate=Instancia duplicada
@@ -51,11 +51,11 @@ versions.version.latest-release=Ultimo lanzamiento
 versions.version.latest-snapshot=Ultima Snapshot
 
 # Crash Screen
-crash.sorry=¡Chingada madre! Parece que se nos crasheo el juego. Perdoname el accidente :(
-crash.vanilla=Como esto no se arregla ni con kolaloka, obtendremos mas detalles del error e investigaremos por que chingados no arranca bien. Puedes ver el error completo abajo
-crash.modded=Le metiste un chingo de mods a esto, no podemos aceptar tu reporte. Como sea, reporta los errores con los creadores de los mods, ellos tendran la respuesta.
-crash.open=Abrir archivo del error
-crash.alert.title=¡Me lleva! Ya crasheo el juego
+crash.sorry=¡Su madre! Parece que cerro el juego. Perdon por el fallo :(
+crash.vanilla=Algo salio muy mal, obtendremos mas detalles del error e investigaremos por que chingados no corre bien. Puedes ver el error completo abajo
+crash.modded=Esto tiene un chingo de mods, no podemos ayudarte. Puedes reportar el fallo a los creadores de los mods.
+crash.open=Abrir reporte
+crash.alert.title=¡Me lleva! Crasheo el juego
 crash.alert.text=Talvez esto tenga solucion. ¿Quieres ver si tiene arreglo?
 crash.alert.button.ignore=Ignorar
 crash.alert.button.open=Abrir pagina web
@@ -70,36 +70,36 @@ about.translation.authors=SrRapero720
 
 # Login Screen
 login.button.type.microsoft=Acceder con Microsoft
-login.button.type.offline=Acceder Offline
+login.button.type.offline=Iniciar Sesion
 login.label.username=Usuario
-login.dropdown.name=Usuarios con Session activa
+login.dropdown.name=Sesiones activas
 login.button.play=Jugar
 login.button.logout=Cerrar session
-login.button.switch.offline=Cambiar a modo Offline
-login.button.switch.online=Cambiar a modo Online
+login.button.switch.offline=Modo offline (sin cuenta)
+login.button.switch.online=Modo Online (microsoft)
 
 # Ajustes
 settings.header.general=General
-settings.header.updates=Actualizaciones
+settings.header.updates=Registro de cambios
 settings.header.about=Acerca de
 settings.footer.button.save=Guardar
 
-settings.option.language.name=Lenguaje
-settings.option.language.info=Necesitas reiniciar el launcher para que surta efecto
-settings.option.accent.name=Color principal
-settings.option.theme.name=Temas
-settings.option.theme.dark.name=Oscuro
-settings.option.sorting.name=Ordenar Instancias
-settings.option.sorting.bylastplayed.name=Ordenar por ultima vez jugado
-settings.option.sorting.byname.name=Ordenar por Nombre
+settings.option.language.name=Idioma
+settings.option.language.info=Debes reiniciar el launcher para que haga efecto el cambio
+settings.option.accent.name=Color Tematico
+settings.option.theme.name=Tema Oscuro
+settings.option.theme.dark.name=Activar
+settings.option.sorting.name=Orden de las Instancias
+settings.option.sorting.bylastplayed.name=Ultima vez jugado
+settings.option.sorting.byname.name=Nombre
 settings.option.default.name=Instancia por defecto
-settings.option.default.hide.name=Ocultar Instancia por defecto
+settings.option.default.hide.name=Ocultar
 settings.option.console.name=Consola del launcher
 settings.option.console.show.name=Mostrar
-settings.about.contributors=Gracias a todos nuestros contribuyentes:
+settings.about.contributors=Gracias a todos los que nos apoyan:
 
 # Administrador de Instancias
-manager.badge.soon=Proximamente
+manager.badge.soon=Muy pronto
 manager.badge.new=Nuevo
 
 manager.header.profiles=Instancias
@@ -112,7 +112,6 @@ manager.profile.menu.duplicate=Duplicar
 manager.profile.menu.delete=Eliminar
 
 manager.editor.header.title=Editar Instancia
-manager.editor.footer.button.save=Guardar
 manager.editor.option.name.name=Nombre de la Instancia
 manager.editor.option.name.placeholder=<Instancia sin nombre>
 manager.editor.option.version.name=Version
@@ -120,17 +119,18 @@ manager.editor.option.directory.name=Carpeta del juego
 manager.editor.option.directory.placeholder=<Carpeta por defecto>
 manager.editor.option.directory.info.label=Algunos mods (no siempre) necesitan ser instalados en la carpeta .minecraft. Para usar la carpeta .minecraft
 manager.editor.option.directory.info.link=Haz click aqui
+manager.editor.footer.button.save=Guardar
 
 manager.editor.button.more=Mas opciones
 manager.editor.option.memory.name=Memoria maxima (RAM)
 manager.editor.option.compatibility.name=Modo de compatibilidad
 manager.editor.option.compatibility.enabled=Activado
 manager.editor.option.visibility.name=Visibilidad del launcher
-manager.editor.option.visibility.hide=Esconder y reabrir al cerrar el juego
-manager.editor.option.visibility.close=Cerrar cuando inicie el juego
-manager.editor.option.visibility.keep=Mantener abierto y muestra la consola del juego
-manager.editor.option.visibility.keep.info=Esta opcion no es la adecuada para PC's de bajos recursos
-manager.editor.option.jvmpath.name=Archivo JAVA
+manager.editor.option.visibility.hide=Esconder (hasta cerrar MC)
+manager.editor.option.visibility.close=Cerrar completamente
+manager.editor.option.visibility.keep=Mostrar launcher y la consola
+manager.editor.option.visibility.keep.info=NOTA: No apta para computadoras de bajos recursos
+manager.editor.option.jvmpath.name=Binarios de JAVA
 manager.editor.option.jvmpath.placeholder=Usar JAVA por defecto
 manager.editor.option.jvmargs.name=Argumentos JVM
 manager.editor.option.jvmargs.info=Esta opcion ignora el argumento -Xmx, usa la opcion de 'Memoria maxima'

--- a/assets/launcher/lang/sklmessages_es_MX.properties
+++ b/assets/launcher/lang/sklmessages_es_MX.properties
@@ -96,7 +96,7 @@ settings.option.default.name=Instancia por defecto
 settings.option.default.hide.name=Ocultar
 settings.option.console.name=Consola del launcher
 settings.option.console.show.name=Mostrar
-settings.about.contributors=Gracias a todos los que nos apoyan:
+settings.about.contributors=Gracias a quienes aportan su ayuda:
 
 # Administrador de Instancias
 manager.badge.soon=Muy pronto


### PR DESCRIPTION
After see traslation i found some translations "weird" because spech context is not the specified in property name, so i made a few changes

Just to add, property "manager.editor.option.visibility.keep.info" is never displayed on launcher