### PR TITLE
Minor tweaks for sklmessages_ru_RU.properties

### DIFF
--- a/assets/launcher/lang/sklmessages_ru_RU.properties
+++ b/assets/launcher/lang/sklmessages_ru_RU.properties
@@ -3,17 +3,18 @@ lang.code=ru_RU
 
 general.issues=Сообщить об ошибке
 general.support=Поддержите нас на Patreon
-general.discord=Присоединяйтесь к нам в Discord
-general.notready=Эта функция пока не готова!
-generic.disabled=Выключено
-generic.enabled=Включено
+general.discord=Присоединяйтесь к нам Discord
+general.notready=Эта функция ещё не готова!
+generic.disabled=Выкл.
+generic.enabled=Вкл.
+# For english speaking readers: 8th and 9th lines were shortened (without use of slang) for better fit.
 generic.soon=Скоро
 generic.new=Новое
 generic.loading=Загрузка...
 tab.news=Новости и обновления
 tab.log=Консоль лаунчера
 tab.output=Консоль игры (%s)
-tab.crash=Краш (%s)
+tab.crash=Сбой (%s)
 
 # Sidebar
 sidebar.label.logged=Вошёл как
@@ -38,32 +39,32 @@ sidebar.game.button.launching=Запуск
 sidebar.game.button.idle=Ожидание
 
 # Versions List
-versions.category.vanilla=Оригинал
+versions.category.vanilla=Оригинальная
 versions.category.modded=Модифицированная
 versions.type.stable=Стабильная
-versions.type.release=Релиз
+versions.type.release=Выпуск
 versions.type.pending=Экспериментальная
-versions.type.snapshot=Снапшот
-versions.type.historical=Историческая
+versions.type.snapshot=Снэпшот
+versions.type.historical=Архивная
 versions.type.old_beta=Старая Бета
 versions.type.old_alpha=Старая Альфа
 versions.type.custom=Настраивамая
-versions.type.removed=Удалённая
+versions.type.removed=Удалёная
 versions.version.latest=Последняя
 versions.version.latestalt=Последняя версия
-versions.version.latest-release=Последний релиз
+versions.version.latest-release=Последний выпуск
 versions.version.latest-snapshot=Последний снапшот
 
 # Crash Screen
-crash.sorry=Ой! Игра крашнулась. Извините за неудобства :(
+crash.sorry=Ой! Игра выдала сбой. Извините за неудобства :(
 crash.vanilla=Используя магию любви мы смогли собрать некоторую информацию о сбое. Вы можете прислать отчёт нам или посмотреть его. Он чуть ниже.
 crash.modded=Вероятно игра была изменена модами. Этот отчёт мы не сможем принять. Если дело в моде, отправьте отчёт автору мода.
-crash.open=Открыть файл краша
-crash.alert.title=Ой! Игра крашнулась.
+crash.open=Открыть файл сбоя
+crash.alert.title=Ой! Игра выдала сбой.
 crash.alert.text=Но вы можете поискать решение проблемы. Проверить сейчас?
 crash.alert.button.ignore=Игнорировать
 crash.alert.button.open=Открыть сайт
-crash.header.title=Игра крашнулась
+crash.header.title=Игра выдала сбой
 crash.footer.button.close=Закрыть
 crash.footer.button.view=Посмотреть отчет
 crash.footer.button.link=Получить ссылку на отчет
@@ -78,7 +79,7 @@ about.translation.authors=WantaSanchez, itzme1on, VoidNmbrZero, Omega596
 # Login Screen
 login.button.type.microsoft=Войти с Microsoft
 login.button.type.offline=Войти Оффлайн
-login.label.username=Никнейм
+login.label.username=Логин
 login.dropdown.name=Авторизированные пользователи
 login.button.play=Играть
 login.button.logout=Выход
@@ -92,7 +93,7 @@ settings.header.about=О нас
 settings.footer.button.save=Сохранить
 
 settings.option.language.name=Язык
-settings.option.language.info=Тебе нужно перезапустить лаунчер для сохранения изменений.
+settings.option.language.info=Вам нужно перезапустить лаунчер для сохранения изменений.
 settings.option.accent.name=Цвет акцента
 settings.option.theme.name=Тема
 settings.option.theme.light.name=Светлая Тема
@@ -109,7 +110,7 @@ settings.option.xmx.info=Используете эти настройки тол
 settings.option.performance.name=Режим производительности
 settings.option.performance.info=Эта опция отключает некоторые анимации
 settings.option.halloween.name=Режим Хэллоуина
-settings.option.xmas.name=Новогодний Режим
+settings.option.xmas.name=Режим Рождества
 settings.option.provider.name=Поставщик модпака по умолчанию
 settings.about.contributors=Спасибо всем нашим соучастникам:
 
@@ -136,7 +137,7 @@ manager.editor.option.version.vanilla=Vanilla
 # dont translate that line ^. It looks terrible compared to untraslated modloader's labels / не переводи строчку сверху она выглядит ужасно так как названия загрузчиков модов не возможно перевести.
 manager.editor.option.directory.name=Директория игры
 manager.editor.option.directory.placeholder=Использовать директорию по умолчанию
-manager.editor.option.directory.info.label=Некоротые моды могут требовать установку для нахождения в папке .minecraft. Для использования директории .minecraft,
+manager.editor.option.directory.info.label=Некоротые моды могут требовать установку для нахождения в папке .minecraft, чтобы использовать её,
 manager.editor.option.directory.info.link=Нажмите сюда.
 
 manager.editor.button.more=Больше настроек
@@ -153,7 +154,7 @@ manager.editor.option.compatibility.info=Эта функция отключае�
 manager.editor.option.visibility.name=Видимость лаунчера
 manager.editor.option.visibility.hide=Скрыть лаунчер и открыть его когда игра закрывается
 manager.editor.option.visibility.close=Закрыть лаунчер при запуске игры
-manager.editor.option.visibility.keep=Оставить лаунче открытым
+manager.editor.option.visibility.keep=Оставить лаунчер открытым
 manager.editor.option.visibility.keep.info=Эта опция не рекоендуется для старых компьтеров
 manager.editor.option.jvmpath.name=Исполняемый файл Java
 manager.editor.option.jvmpath.placeholder=Исполязовать встроенную Java
@@ -181,10 +182,10 @@ alert.downgrade.window.title=Предупреждение о несовмест�
 alert.downgrade.label.title=Сбросить сборки?
 alert.downgrade.label.body=Кажется ты использовал лаунчер отличающийся от этого! \nЕсли ты вернёшся нам придётся сбросить твою конфигурацию.
 alert.downgrade.button.reset=Я уверен. Сбрось мои настройки.
-alert.downgrade.button.cancel=Забудь, закрой лаунчер
+alert.downgrade.button.cancel=Забей, закрой лаунчер
 
 alert.invalid.window.title=Предупреждение неверных версий
-alert.invalid.label.title=Неверные версии зафиксированы :(
+alert.invalid.label.title=Зафиксированы неверные версии :(
 alert.invalid.label.body=Эта версия неверная и не может быть загружена. \nЗаметка: Мы не поддерживаем версии скачанные с других лаунчеров.
 alert.invalid.button.delete=Удалить неверные версии
 alert.invalid.button.close=Закрыть


### PR DESCRIPTION
Altered some words to their russian synonyms for better understading by someone not knowing much about minecraft. Example: word "crash" was written on russian without translating it (same word, sounding same, written with russian characters), correct translation is "сбой".