### PR TITLE
Update sklmessages_fr_FR.properties

### DIFF
--- a/assets/launcher/lang/sklmessages_fr_FR.properties
+++ b/assets/launcher/lang/sklmessages_fr_FR.properties
@@ -18,14 +18,14 @@ tab.output=Sortie du jeu (%s)
 tab.crash=Rapport de plantage (%s)
 
 # Sidebar
-sidebar.label.logged=Connecté comme
+sidebar.label.logged=Connecté en tant que
 sidebar.label.player=Joueur
 sidebar.button.switch=Changer d'utilisateur
 sidebar.button.settings=Paramètres
 sidebar.button.manager=Gestionnaire d'installations
 sidebar.menu.item.edit=Modifier l'installation
 sidebar.menu.item.duplicate=Dupliquer l'installation
-sidebar.menu.item.browse=Ouvrir le dossier de l'installation
+sidebar.menu.item.browse=Ouvrir le dossier d'installation
 sidebar.menu.item.delete=Supprimer l'installation
 sidebar.game.button.play=Jouer
 sidebar.game.button.play.demo=Jouer à la démo
@@ -44,7 +44,7 @@ versions.category.vanilla=Vanilla
 versions.category.modded=Moddé
 versions.type.stable=Stable
 versions.type.release=Release
-versions.type.pending=Expérimental
+versions.type.pending=en attente
 versions.type.snapshot=Snapshot
 versions.type.historical=Historique
 versions.type.old_beta=Ancienne beta


### PR DESCRIPTION
So i think those 3 change would fit better
"Connecter comme.." meant "Connected like.." so i changed it to "Connecte en tant que.." wich is more suitable to speak about an entity/person. Pending wich mean "En attente" and not "experimental" like an experiment. and the last change is juste a short-cut, multiple were said shorter exept this one... It was Weird.