### PR TITLE
🔀 Update sklmessages_pt_BR.properties

### DIFF
--- a/assets/launcher/lang/sklmessages_pt_BR.properties
+++ b/assets/launcher/lang/sklmessages_pt_BR.properties
@@ -35,7 +35,7 @@ sidebar.game.button.preparing=Preparando
 sidebar.game.button.downloading=Baixando
 sidebar.game.button.installing=Instalando
 sidebar.game.button.launching=Iniciando
-sidebar.game.button.idle=Ausente
+sidebar.game.button.idle=Ocioso
 
 # Versions List
 versions.category.vanilla=Vanilla
@@ -63,10 +63,13 @@ crash.alert.title=Opa! Seu jogo parou
 crash.alert.text=Mas encontramos uma possível solução para o seu problema. Você quer verificar isso agora?
 crash.alert.button.ignore=Ignorar
 crash.alert.button.open=Abrir website
-crash.header.title=Minecraft crashou
+
+# Crash Popup
+crash.header.title=Minecraft parou
 crash.footer.button.close=Fechar
-crash.footer.button.view=Ver report do crash
-crash.footer.button.link=Pegar link para o report do crash
+crash.footer.button.view=Ver relatório de parada
+crash.footer.button.link=Pegar link para o relatório de parada
+
 # Alerts
 alert.button.confirm=Confirmar
 alert.button.cancel=Cancelar
@@ -101,27 +104,28 @@ settings.option.theme.black.name=Tema Negro
 settings.option.sorting.name=Ordenação de Instalações
 settings.option.sorting.bylastplayed.name=Ordenar instalações por último jogado
 settings.option.sorting.byname.name=Ordenar instalações por nome
-settings.option.sorting.custom.name=Ordenar customizadamente
+settings.option.sorting.custom.name=Ordenar por preferência
 settings.option.default.name=Instalações Padrão
 settings.option.console.name=Console do Launcher
-settings.option.xmx.name=Permitir argumentos Xmx
+settings.option.xmx.name=Permitir Argumentos Xmx
 settings.option.xmx.info=Apenas use essa opção se sabe o que está fazendo!
-settings.option.performance.name=Modo de performance
-settings.option.performance.info=Essa opção desativará algumas animações
+settings.option.performance.name=Modo de Desempenho
+settings.option.performance.info=Essa opção desativa algumas animações
 settings.option.halloween.name=Modo de Halloween
-settings.option.xmas.name=Modo natalino
-settings.option.provider.name=Provedor padrão de datapacks
-settings.option.dgpu.name=Use Dedicated GPU
-settings.option.dgpu.info=Forces the use of the dedicated GPU on Windows
+settings.option.xmas.name=Modo Natalino
+settings.option.provider.name=Provedor Padrão de Datapacks
+settings.option.dgpu.name=Usar GPU Dedicada
+settings.option.dgpu.info=Força o uso da GPU dedicada no Windows
+
 settings.about.contributors=Obrigado a todos os colaboradores:
 
 # Installations Manager
 manager.header.profiles=Instalações
 manager.header.modpacks=Modpacks
 manager.header.mods=Mods
-manager.header.resourcepacks=Resource Packs
-manager.header.maps=Maps
-manager.header.shaders=Shaders
+manager.header.resourcepacks=Pacotes de Recursos
+manager.header.maps=Mapas
+manager.header.shaders=Sombreadores
 manager.button.new=Nova Instalação
 manager.button.import=Importar modpack
 manager.profile.button.play=Jogar
@@ -147,7 +151,7 @@ manager.editor.option.resolution.width=Largura
 manager.editor.option.resolution.fullscreen=Tela cheia
 manager.editor.option.memory.name=Memória Máxima (RAM)
 manager.editor.option.memory.auto=AUTO
-manager.editor.option.memory.disabled.info=Essa opção está desativada pois você possui "Permitir argumentos Xmx" ativado
+manager.editor.option.memory.disabled.info=Essa opção está desativada pois você possui "Permitir Argumentos Xmx" ativado
 manager.editor.option.compatibility.name=Modo de Compatibilidade
 manager.editor.option.compatibility.enabled=Ativado
 manager.editor.option.compatibility.info=Esta opção desabilita o sistema de skins, use somente se necessário
@@ -160,21 +164,24 @@ manager.editor.option.jvmpath.name=Executável Java
 manager.editor.option.jvmpath.placeholder=Usar o Java Runtime integrado
 manager.editor.option.jvmargs.name=Argumentos da JVM
 manager.editor.option.jvmargs.info=Esta opção ignora os argumentos -Xmx, use Memória Máxima em vez disso
+
 manager.modpack.search=Pesquisar modpacks
 manager.modpack.search.unavailable=A pesquisa está indisponível
 manager.modpack.search.noresults=Sem resultados encontrados
-manager.modpack.header.info=Informações do modpack
+manager.modpack.header.info=Informações do Modpack
 manager.modpack.header.back=Voltar
 manager.modpack.info.install=Instalar última versão
+# <modpack name> by <modpack author>
 manager.modpack.info.by=por
-manager.modpack.details.releasedate=Data de lançamento
-manager.modpack.details.filename=Nome do arquivo
+manager.modpack.details.releasedate=Data de Lançamento
+manager.modpack.details.filename=Nome do Arquivo
 manager.modpack.details.gameversion=Versão do Minecraft
 manager.modpack.details.action.install=Instalar
 manager.modpack.pagination.previous=Anterior
 manager.modpack.pagination.next=Próximo
+
 # New Alerts
-alert.duplicate.window.title=Aviso de instância duplicada
+alert.duplicate.window.title=Aviso de Instância Duplicada
 alert.duplicate.label.title=Você já tem uma instância de Minecraft rodando.
 alert.duplicate.label.body=Se você iniciar outra no mesmo diretório, elas podem entrar em conflito e corromper seus dados. \nIsto pode causar muitos problemas, em singleplayer ou não. Não seremos responsáveis por qualquer coisa que dê errado. \nVocê quer iniciar outra instância de Minecraft mesmo assim? \nVocê pode resolver este problema iniciando o jogo em um diretório diferente (veja o botão "Editar" na instalação).
 


### PR DESCRIPTION
[1] - Translated some strings
[2] - Reversed sidebar.game.button.idle to "Ocioso" since "Ausente" is more like "missing"
[3] - Added some line breaks and comments to make it appear like the original file
[4] - Changed "crashou" to "parou" to match other strings
[5] - Capitalised some titles. In Portuguese, all words in titles can be capitalised
[6] - "Customizadamente" doesn't exist in Portuguese, let's use "por preferência" (by preference)
[7] - "Resource Packs" is translated in game as "Pacote de Recursos", let's use the same
[8] - "Shaders" is translated in Sodium as "Sombreadores", let's keep the pattern