### PR TITLE
feat: update hu_HU translations

### DIFF
--- a/assets/launcher/lang/sklmessages_hu_HU.properties
+++ b/assets/launcher/lang/sklmessages_hu_HU.properties
@@ -57,10 +57,10 @@ versions.version.latest-snapshot=Legújabb Snapshot
 # Crash Screen
 crash.sorry=Húha! Úgy tűnik, a játék összeomlott. Elnézést a kellemetlenségért :(
 crash.vanilla=A varázslat erejével, sikerült szereznünk néhány részletet az összeomlásról, és a lehető leghamarabb elkezdjük vizsgálni a dolgot. A teljes jelentést láthatod alul.
-crash.modded=Úgy tűnik, a játékod módosítva lehet, így nem fogadhatjuk el ezt az összeomlás jelentést. Viszont, ha modokat használsz, akkor ezt elküldheted a mod készítöinek, hogy megvizsgálják.
+crash.modded=Úgy tűnik, a játékod mod-olt, így nem fogadhatjuk el ezt az összeomlás jelentést. Viszont, ha modokat használsz, akkor ezt elküldheted a mod készítöinek, hogy megvizsgálják.
 crash.open=Jelentés fájl megnyitása
 crash.alert.title=Hoppá! A játék összeomlott
-crash.alert.text=Viszont találtunk egy lehetséges megoldást a problémádra. Meg szeretné nézni?
+crash.alert.text=Viszont találtunk egy lehetséges megoldást a problémádra. Meg szeretnéd nézni?
 crash.alert.button.ignore=Mellőzés
 crash.alert.button.open=Oldal megnyitása
 crash.header.title=A Játék Összeomlott
@@ -112,8 +112,8 @@ settings.option.performance.info=Ez az opció letilt néhány animációt
 settings.option.halloween.name=Halloween Mód
 settings.option.xmas.name=Karácsonyi Mód
 settings.option.provider.name=Alapértelmezett Modpack Szolgáltató
-settings.option.dgpu.name=Use Dedicated GPU
-settings.option.dgpu.info=Forces the use of the dedicated GPU on Windows
+settings.option.dgpu.name=Dedikált videókártya használata
+settings.option.dgpu.info=A dedikált videókártya használatát garantálja Windows-on
 settings.about.contributors=Köszönet a hozzájárulóknak:
 
 # Installations Manager
@@ -148,7 +148,7 @@ manager.editor.option.resolution.width=Szélesség
 manager.editor.option.resolution.fullscreen=Teljes képernyő
 manager.editor.option.memory.name=Maximum Memória (RAM)
 manager.editor.option.memory.auto=AUTO
-manager.editor.option.memory.disabled.info=Ez az opció ki van kapcsolva, mivel az "Xmx Argumentumok Engedélyezése"-t bekapcsoltad
+manager.editor.option.memory.disabled.info=Ez az opció ki van kapcsolva, mivel az "Xmx Argumentumok Engedélyezése" opciót bekapcsoltad
 manager.editor.option.compatibility.name=Kompatibilitási Mód
 manager.editor.option.compatibility.enabled=Bekapcsolva
 manager.editor.option.compatibility.info=Ez az opció kikapcsolja a skin rendszert, csak szükség esetén használd


### PR DESCRIPTION
Translate new strings, change some translations.

I also noticed that there doesn't seem to be a line for the following string:
![image](https://github.com/user-attachments/assets/87a51aa5-3b24-449a-ac5b-d0a65ef4fb4e)
