### PR TITLE
Update sklmessages_en_US.properties

### DIFF
--- a/assets/launcher/lang/sklmessages_en_US.properties
+++ b/assets/launcher/lang/sklmessages_en_US.properties
@@ -58,8 +58,8 @@ versions.version.latest-snapshot=Latest Snapshot
 
 # Crash Screen
 crash.sorry=Uhoh! It looks like the game has crashed. Sorry for the inconvenience :(
-crash.vanilla=Using magic and love, we\'ve managed to gather some details about the crash, and we will investigate this as soon as we can. You can see the full report below.
-crash.modded=We think your game may be modded, and as such we can\'t accept this crash report. However, if you do indeed use mods, please send this to the mod authors to take a look at.
+crash.vanilla=Using magic and love, we've managed to gather some details about the crash, and we will investigate this as soon as we can. You can see the full report below.
+crash.modded=We think your game may be modded, and as such we can't accept this crash report. However, if you do indeed use mods, please send this to the mod authors to take a look at.
 crash.open=Open report file
 crash.alert.title=Oops! The game has crashed
 crash.alert.text=But we found a possible solution to your problem. Do you want to check it now?


### PR DESCRIPTION
Fixed 2 typos - In line 61 and 62.
On line 61 - changed "crash.vanilla=Using magic and love, **we\'ve** managed to gather some details about the crash, and we will investigate this as soon as we can. You can see the full report below." Changed "we\'ve" to "we've".
On line 63 - changed "crash.modded=We think your game may be modded, and as such we **can\'t** accept this crash report. However, if you do indeed use mods, please send this to the mod authors to take a look at.
crash.open=Open report file
crash.alert.title=Oops! The game has crashed". Changed "can\'t" to "can't".

That's it!