### PR TITLE
Updated and fixed sklmessages_ro_RO.properties

### DIFF
--- a/assets/launcher/lang/sklmessages_ro_RO.properties
+++ b/assets/launcher/lang/sklmessages_ro_RO.properties
@@ -31,7 +31,7 @@ sidebar.game.button.play.offline=Joacă Offline
 sidebar.game.button.playing=Se lansează
 sidebar.game.button.already=Deja lansat
 sidebar.game.button.loading=Se Incarcă
-sidebar.game.button.preparing=Se Pregatește
+sidebar.game.button.preparing=Se Pregătește
 sidebar.game.button.downloading=Se Descarcă
 sidebar.game.button.installing=Se Instalează
 sidebar.game.button.launching=Se Lansează
@@ -39,7 +39,7 @@ sidebar.game.button.idle=În Așteptare
 
 # Versions List
 versions.category.vanilla=Vanilla
-versions.category.modded=Modded
+versions.category.modded=Modificat
 versions.type.stable=Stabil
 versions.type.release=Release
 versions.type.pending=Experimental
@@ -47,7 +47,7 @@ versions.type.snapshot=Snapshot
 versions.type.historical=Istoric
 versions.type.old_beta=Beta Vechi
 versions.type.old_alpha=Alpha Vechi
-versions.type.custom=Custom
+versions.type.custom=Personalizat
 versions.type.removed=Șterse
 versions.version.latest=Cea mai nouă
 versions.version.latestalt=Cea mai nouă versiune
@@ -55,31 +55,31 @@ versions.version.latest-release=Cea mai nouă versiune
 versions.version.latest-snapshot=Cel mai nou Snapshot
 
 # Crash Screen
-crash.sorry=Se pare că jocul tău a întampinat o problemă și s-a închis, Ne pare rău pentru inconveniență :(
-crash.vanilla=Am colectat cateva informații despre conflictul întâmpinat și le vom investiga. Mai jos poți vedea un raport complet.
-crash.modded=Jocul tău conține moduri. Te rugăm să trimiți acest raport și autorilor modurilor de mai jos.
-crash.open=Deschideți Raportul
+crash.sorry=Se pare că jocul tău a întampinat o problemă și s-a închis, ne pare rău de problemă :(
+crash.vanilla=Folosind magia și iubirea, am reușit să colectăm niște informații despre eroare pe care o vom investiga cât de curând putem. Mai jos poți vedea un raport complet.
+crash.modded=Jocul tău poate conține mod-uri. Te rugăm să trimiți acest raport de eroare autorilor mod-urilor de mai jos.
+crash.open=Deschide Raportul
 crash.alert.title=Jocul tău a întampinat o problemă.
 crash.alert.text=Dar am găsit o solutie posibilă, vrei să o încerci acum?
 crash.alert.button.ignore=Ignoră
 crash.alert.button.open=Deschide site-ul
-crash.header.title=Jocul a dat crash
+crash.header.title=Ups! Jocul a dat crash
 crash.footer.button.close=Închide
 crash.footer.button.view=Vizualizează raport
-crash.footer.button.link=Obține linkul raportului
+crash.footer.button.link=Obține link-ul raportului
 # Alerts
 alert.button.confirm=Confirmă
 alert.button.cancel=Anulează
 
 # About
 about.translation=Traducere facută de:
-about.translation.authors=Silver Crawl /aka [TitaniuMark], zUltra
+about.translation.authors=Silver Crawl /aka [TitaniuMark], zUltra, Douper
 
 # Login Screen
-login.button.type.microsoft=Conectează-te cu contul Microsoft
+login.button.type.microsoft=Conectează-te folosind contul Microsoft
 login.button.type.offline=Conetează-te offline
 login.label.username=Nume de utilizator
-login.dropdown.name=Utilizatori Conectați
+login.dropdown.name=Utilizatori conectați
 login.button.play=Intră
 login.button.logout=Deconectează-te
 login.button.switch.offline=Schimbă pe modul Offline
@@ -93,7 +93,7 @@ settings.footer.button.save=Salvează
 
 settings.option.language.name=Limbă
 settings.option.language.info=Va trebui să repornești launcher-ul pentru a aplica modificările.
-settings.option.accent.name=Culoare de accent
+settings.option.accent.name=Culoare accentuată
 settings.option.theme.name=Temă
 settings.option.theme.light.name=Temă luminoasă
 settings.option.theme.dark.name=Temă întunecată
@@ -117,13 +117,13 @@ settings.about.contributors=Mulțumiri tuturor contribuitorilor:
 
 # Installations Manager
 manager.header.profiles=Instalări
-manager.header.modpacks=Pachete de moduri
+manager.header.modpacks=Modpack-uri
 manager.header.mods=Moduri
-manager.header.resourcepacks=Pachete de resurse
-manager.header.maps=Mape
-manager.header.shaders=Shaders
+manager.header.resourcepacks=Resourcepack-uri
+manager.header.maps=Hărți
+manager.header.shaders=Shadere
 manager.button.new=Instalare nouă
-manager.button.import=Importă pachet de moduri
+manager.button.import=Importă modpack
 manager.profile.button.play=Joacă
 manager.profile.menu.edit=Editează
 manager.profile.menu.duplicate=Duplică
@@ -135,10 +135,10 @@ manager.editor.option.name.name=Numele instalării
 manager.editor.option.name.placeholder=Instalare neintitulată
 manager.editor.option.version.name=Versiunea
 manager.editor.option.version.vanilla=Vanilla
-manager.editor.option.directory.name=Dosarul jocului
-manager.editor.option.directory.placeholder=Utilizează dosarul împlicit
+manager.editor.option.directory.name=Folder-ul jocului
+manager.editor.option.directory.placeholder=Utilizează folder-ul împlicit
 manager.editor.option.directory.info.label=Unele moduri pot necesita ca instalarea să fie localizată in folderul .minecraft. Pentru a folosi folder-ul .minecraft,
-manager.editor.option.directory.info.link=click aici.
+manager.editor.option.directory.info.link=da click aici.
 
 manager.editor.button.more=Mai multe opțiuni
 manager.editor.option.resolution.name=Rezoluție
@@ -146,8 +146,8 @@ manager.editor.option.resolution.height=Înălțime
 manager.editor.option.resolution.width=Lățime
 manager.editor.option.resolution.fullscreen=Ecran complet
 manager.editor.option.memory.name=Memorie Maximă (RAM)
-manager.editor.option.memory.auto=Auto
-manager.editor.option.memory.disabled.info=Această opțiune este dezactivată deoarece opțiunea "Permite argumente Xmx" este activă
+manager.editor.option.memory.auto=Automat
+manager.editor.option.memory.disabled.info=Această opțiune este dezactivată, deoarece opțiunea "Permite argumente Xmx" este activă
 manager.editor.option.compatibility.name=Mod de compatibilitate
 manager.editor.option.compatibility.enabled=Activat
 manager.editor.option.compatibility.info=Această opțiune dezactivează sistemul de skin-uri, folosește această optiune doar dacă ai nevoie de ea
@@ -155,32 +155,32 @@ manager.editor.option.visibility.name=Vizibilitatea launcher-ului
 manager.editor.option.visibility.hide=Ascunde launcher-ul și redeschide atunci când jocul este închis
 manager.editor.option.visibility.close=Închide launcher-ul atunci când jocul este deschis
 manager.editor.option.visibility.keep=Ține launcher-ul deschis și afișează consola
-manager.editor.option.visibility.keep.info=Această opțiune nu este recomandată pentru calculatoarele low-end
+manager.editor.option.visibility.keep.info=Această opțiune nu este recomandată pentru calculatoarele cu performanță redusă
 manager.editor.option.jvmpath.name=Executabil Java
 manager.editor.option.jvmpath.placeholder=Utilizează pachetul de rulare Java 
 manager.editor.option.jvmargs.name=Argumente JVM
 manager.editor.option.jvmargs.info=Această opțiune ignoră argumentele -Xmx, utilizați opțiunea Memorie Maximă
-manager.modpack.search=Caută pachete de moduri
+manager.modpack.search=Caută modpack-uri
 manager.modpack.search.unavailable=Căutarea este indisponibilă
 manager.modpack.search.noresults=Niciun rezultat găsit
-manager.modpack.header.info=Informații despre pachetul de moduri
+manager.modpack.header.info=Informații despre modpack
 manager.modpack.header.back=Înapoi
 manager.modpack.info.install=Instalează cel mai recent
 manager.modpack.info.by=de
 manager.modpack.details.releasedate=Data de lansare
 manager.modpack.details.filename=Numele fișierului
-manager.modpack.details.gameversion=Versiunea de joc
+manager.modpack.details.gameversion=Versiunea jocului
 manager.modpack.details.action.install=Instalează
 manager.modpack.pagination.previous=Precedentul
 manager.modpack.pagination.next=Următorul
 # New Alerts
 alert.duplicate.window.title=Avertizare: Instanță dublă
-alert.duplicate.label.title=Deja aveți o instanță de Minecraft deschisă.
-alert.duplicate.label.body=Dacă deschideți încă una în același dosar, lumile pot deveni corupte. \nAceasta poate cauza multe probleme, în Singleplayer sau altfel. Nu suntem responsabili pentru orice problemă cauzată de această acțiune.\nSunteți sigur că vreți să deschideți o altă instanță de Minecraft? \nPuteți rezolva această problemă prin lansarea jocului într-un dosar diferit. (vedeți butonul "Editează instalarea").
+alert.duplicate.label.title=Deja ai o instanță de Minecraft deschisă.
+alert.duplicate.label.body=Dacă deschizi încă una în același folder, lumile pot deveni corupte. \nAceasta poate cauza multe probleme, în Singleplayer sau altfel. Nu suntem responsabili pentru orice problemă cauzată de această acțiune.\nEști sigur că vrei să deschizi o altă instanță de Minecraft? \nPoți rezolva această problemă prin lansarea jocului într-un folder diferit. (vezi butonul "Editează instalarea").
 
 alert.downgrade.window.title=Avertizare: Instalări incompatibile
-alert.downgrade.label.title=Resetați instalările?
-alert.downgrade.label.body=Se pare că ați folosit un launcher diferit pe lângă acesta! \nDacă vă intoarceți la acesta, va trebui să vă resetăm setările.
+alert.downgrade.label.title=Reseezi instalările?
+alert.downgrade.label.body=Se pare că ai folosit un launcher diferit pe lângă acesta! \nDacă te întorci la acesta, va trebui să îți resetăm setările.
 alert.downgrade.button.reset=Sunt sigur. Resetează-mi setările
 alert.downgrade.button.cancel=M-am răzgândit, închide launcher-ul
 


### PR DESCRIPTION
I understand that I've replaced some words with the english counterparts, but that's because in the Minecraft Romanian community, many people use the english words instead of the Romanian words, making it closer to how a Romanian speaker playing Minecraft would naturally talk.