### PR TITLE
sklmessages_es_VE.properties

### DIFF
--- a/assets/launcher/lang/sklmessages_es_VE.properties
+++ b/assets/launcher/lang/sklmessages_es_VE.properties
@@ -1,0 +1,201 @@
+lang.name=Español (Venezuela)
+lang.code=es_VE
+
+general.issues=Reportar un problema
+general.support=Apóyanos en Patreon
+general.discord=Únete a nuestro Discord
+general.notready=¡Esta función todavía no está lista!
+
+generic.disabled=Desactivado
+generic.enabled=Activado
+generic.soon=Próximamente
+generic.new=Nuevo
+generic.loading=Cargando...
+
+tab.news=Noticias y Actualizaciones
+tab.log=Registro del Launcher
+tab.output=Salida del Juego (%s)
+tab.crash=Reporte de Falla (%s)
+
+# Sidebar
+sidebar.label.logged=Conectado como
+sidebar.label.player=Jugador
+sidebar.button.switch=Cambiar Usuario
+sidebar.button.settings=Ajustes del Launcher
+sidebar.button.manager=Administrador de Instancias
+sidebar.menu.item.edit=Editar instancia
+sidebar.menu.item.duplicate=Duplicar instancia
+sidebar.menu.item.browse=Abrir carpeta de la instancia
+sidebar.menu.item.delete=Eliminar instancia
+sidebar.game.button.play=Jugar
+sidebar.game.button.play.demo=Jugar Demo
+sidebar.game.button.play.offline=Jugar sin conexión
+sidebar.game.button.playing=Jugando
+sidebar.game.button.already=Ya estás jugando
+sidebar.game.button.loading=Cargando
+sidebar.game.button.preparing=Preparando
+sidebar.game.button.downloading=Descargando
+sidebar.game.button.installing=Instalando
+sidebar.game.button.launching=Iniciando
+sidebar.game.button.idle=Inactivo
+
+# Versions List
+versions.category.vanilla=Vanilla
+versions.category.modded=Modificada
+versions.type.stable=Estable
+versions.type.release=Lanzamiento
+versions.type.pending=Experimental
+versions.type.snapshot=Snapshot
+versions.type.historical=Históricas
+versions.type.old_beta=Beta Antigua
+versions.type.old_alpha=Alpha Antigua
+versions.type.custom=Personalizada
+versions.type.removed=Eliminada
+versions.version.latest=Última
+versions.version.latestalt=Última Versión
+versions.version.latest-release=Último Lanzamiento
+versions.version.latest-snapshot=Última Snapshot
+
+# Crash Screen
+crash.sorry=¡Rayos! Parece que el juego se cerró inesperadamente. Disculpa las molestias :(
+crash.vanilla=Nuestro sistema pudo recolectar algunos detalles sobre la falla y la investigaremos tan pronto como podamos. Puedes ver el reporte completo a continuación.
+crash.modded=Creemos que tu juego puede estar modificado, y por eso no podemos aceptar este reporte de falla. Sin embargo, si de pana usas mods, por favor envíale esto a los creadores de los mods para que le echen un ojo.
+crash.open=Abrir archivo del reporte
+crash.alert.title=¡Opa! El juego falló
+crash.alert.text=Pero encontramos una posible solución a tu problema. ¿Quieres revisarla ahora?
+crash.alert.button.ignore=Ignorar
+crash.alert.button.open=Abrir página web
+
+# Crash Popup
+crash.header.title=El Juego Falló
+crash.footer.button.close=Cerrar
+crash.footer.button.view=Ver reporte
+crash.footer.button.link=Obtener enlace al reporte
+
+# Alerts
+alert.button.confirm=Confirmar
+alert.button.cancel=Cancelar
+
+# About
+about.translation=Traducido por:
+about.translation.authors=Papiaceituna
+
+# Login Screen
+login.button.type.microsoft=Iniciar sesión con Microsoft
+login.button.type.offline=Iniciar sin conexión
+login.label.username=Nombre de usuario
+login.dropdown.name=Usuarios Conectados
+login.button.play=Jugar
+login.button.logout=Cerrar Sesión
+login.button.switch.offline=Cambiar a modo sin conexión
+login.button.switch.online=Cambiar a modo en línea
+
+# Settings
+settings.header.general=General
+settings.header.updates=Actualizaciones
+settings.header.about=Acerca de
+settings.footer.button.save=Guardar
+
+settings.option.language.name=Idioma
+settings.option.language.info=Necesitas reiniciar el launcher para aplicar los cambios.
+settings.option.accent.name=Color de Acento
+settings.option.theme.name=Tema
+settings.option.theme.light.name=Tema Claro
+settings.option.theme.dark.name=Tema Oscuro
+settings.option.theme.black.name=Tema Negro
+settings.option.sorting.name=Orden de las Instancias
+settings.option.sorting.bylastplayed.name=Ordenar Instancias por última vez jugada
+settings.option.sorting.byname.name=Ordenar Instancias por nombre
+settings.option.sorting.custom.name=Orden personalizado
+settings.option.default.name=Ocultar Instancias por Defecto
+settings.option.console.name=Mostrar Consola del Launcher
+settings.option.xmx.name=Permitir Argumentos Xmx
+settings.option.xmx.info=Usa esta opción si sabes lo que estás haciendo
+settings.option.performance.name=Modo Rendimiento
+settings.option.performance.info=Esta opción desactiva algunas animaciones
+settings.option.halloween.name=Modo Halloween
+settings.option.xmas.name=Modo Parranda Navideña
+settings.option.provider.name=Proveedor de Modpacks por Defecto
+settings.option.dgpu.name=Usar GPU Dedicada
+settings.option.dgpu.info=Forzar el uso de la GPU dedicada en Windows
+
+settings.about.contributors=Gracias a todos los colaboradores:
+
+# Installations Manager
+manager.header.profiles=Instancias
+manager.header.modpacks=Paquetes de Mods
+manager.header.mods=Mods
+manager.header.resourcepacks=Paquetes de Recursos
+manager.header.maps=Mapas
+manager.header.shaders=Shaders
+
+manager.button.new=Nueva Instancia
+manager.button.import=Importar modpack
+manager.profile.button.play=Jugar
+manager.profile.menu.edit=Editar
+manager.profile.menu.duplicate=Duplicar
+manager.profile.menu.delete=Eliminar
+
+manager.editor.header.title=Editar Instancia
+manager.editor.footer.button.save=Guardar
+manager.editor.option.name.name=Nombre de la Instancia
+manager.editor.option.name.placeholder=Instancia sin nombre
+manager.editor.option.version.name=Versión
+manager.editor.option.version.vanilla=Vanilla
+manager.editor.option.directory.name=Directorio del Juego
+manager.editor.option.directory.placeholder=Usar directorio por defecto
+manager.editor.option.directory.info.label=Algunos mods pueden requerir que la Instancia esté en la carpeta .minecraft. Para usar el directorio de juego .minecraft,
+manager.editor.option.directory.info.link=haz clic aquí.
+
+manager.editor.button.more=Más Opciones
+manager.editor.option.resolution.name=Resolución
+manager.editor.option.resolution.height=Alto
+manager.editor.option.resolution.width=Ancho
+manager.editor.option.resolution.fullscreen=Pantalla Completa
+manager.editor.option.memory.name=Memoria Máxima (RAM)
+manager.editor.option.memory.auto=AUTO
+manager.editor.option.memory.disabled.info=Esta opción está desactivada porque tienes "Permitir Argumentos Xmx" activado
+manager.editor.option.compatibility.name=Modo de Compatibilidad
+manager.editor.option.compatibility.enabled=Activado
+manager.editor.option.compatibility.info=Esta opción desactiva el sistema de skins, úsala solo si es necesario
+manager.editor.option.visibility.name=Visibilidad del Launcher
+manager.editor.option.visibility.hide=Ocultar el launcher y reabrirlo cuando el juego se cierre
+manager.editor.option.visibility.close=Cerrar el launcher cuando el juego inicie
+manager.editor.option.visibility.keep=Mantener el launcher abierto
+manager.editor.option.visibility.keep.info=No se recomienda esta opción para computadoras de bajos recursos
+manager.editor.option.jvmpath.name=Ejecutable de Java
+manager.editor.option.jvmpath.placeholder=Usar el Java que viene incluido
+manager.editor.option.jvmargs.name=Argumentos de la JVM
+manager.editor.option.jvmargs.info=Esta opción ignora los argumentos -Xmx, usa la Memoria Máxima en su lugar
+
+manager.modpack.search=Buscar modpacks
+manager.modpack.search.unavailable=La búsqueda no está disponible
+manager.modpack.search.noresults=No se encontraron resultados
+manager.modpack.header.info=Información del Modpack
+manager.modpack.header.back=Atrás
+manager.modpack.info.install=Instalar la última
+# <modpack name> by <modpack author>
+manager.modpack.info.by=por
+manager.modpack.details.releasedate=Fecha de Lanzamiento
+manager.modpack.details.filename=Nombre del Archivo
+manager.modpack.details.gameversion=Versión del Juego
+manager.modpack.details.action.install=Instalar
+manager.modpack.pagination.previous=Anterior
+manager.modpack.pagination.next=Siguiente
+
+# New Alerts
+alert.duplicate.window.title=Advertencia de Instancia Duplicada
+alert.duplicate.label.title=Ya tienes una instancia de Minecraft corriendo.
+alert.duplicate.label.body=Si inicias otra en el mismo directorio, podrían chocar y corromper tus mundos guardados. \nEsto podría causar muchos problemas, en un jugador o de otra forma. No nos hacemos responsables por nada que pueda salir mal. \n¿Quieres iniciar otra instancia de Minecraft, a pesar de esto? \nPuedes resolver este problema iniciando el juego en otro directorio (mira el botón "Editar instalación").
+
+alert.downgrade.window.title=Advertencia de Instancias Incompatibles
+alert.downgrade.label.title=¿Restablecer instalaciones?
+alert.downgrade.label.body=¡Parece que has usado un launcher diferente a este! \nSi vuelves a usar este, necesitaremos restablecer tu configuración.
+alert.downgrade.button.reset=Estoy seguro. Restablecer mis ajustes
+alert.downgrade.button.cancel=Olvídalo, cerrar este launcher
+
+alert.invalid.window.title=Advertencia de Versiones Inválidas
+alert.invalid.label.title=Se detectaron versiones inválidas :(
+alert.invalid.label.body=Las siguientes versiones son inválidas y no se pueden cargar. \nNota: No soportamos algunas versiones descargadas a través de otros launchers.
+alert.invalid.button.delete=Eliminar versiones inválidas
+alert.invalid.button.close=Cerrar

--- a/assets/launcher/lang/sklmessages_es_VE.properties
+++ b/assets/launcher/lang/sklmessages_es_VE.properties
@@ -22,7 +22,7 @@ sidebar.label.logged=Conectado como
 sidebar.label.player=Jugador
 sidebar.button.switch=Cambiar Usuario
 sidebar.button.settings=Ajustes del Launcher
-sidebar.button.manager=Administrador de Instancias
+sidebar.button.manager=Administrador de instancias
 sidebar.menu.item.edit=Editar instancia
 sidebar.menu.item.duplicate=Duplicar instancia
 sidebar.menu.item.browse=Abrir carpeta de la instancia
@@ -57,8 +57,8 @@ versions.version.latest-release=Último Lanzamiento
 versions.version.latest-snapshot=Última Snapshot
 
 # Crash Screen
-crash.sorry=¡Rayos! Parece que el juego se cerró inesperadamente. Disculpa las molestias :(
-crash.vanilla=Nuestro sistema pudo recolectar algunos detalles sobre la falla y la investigaremos tan pronto como podamos. Puedes ver el reporte completo a continuación.
+crash.sorry=¡Nawará! Parece que el juego se cerró inesperadamente. Disculpa las molestias :(
+crash.vanilla=Con un poquito de magia y buena nota logramos pescar la vaina del fallo. Tranquilo, ya lo vamos a revisar. Mientras tanto, échale un ojo al reporte completo aquí abajo.
 crash.modded=Creemos que tu juego puede estar modificado, y por eso no podemos aceptar este reporte de falla. Sin embargo, si de pana usas mods, por favor envíale esto a los creadores de los mods para que le echen un ojo.
 crash.open=Abrir archivo del reporte
 crash.alert.title=¡Opa! El juego falló
@@ -82,11 +82,11 @@ about.translation.authors=Papiaceituna
 
 # Login Screen
 login.button.type.microsoft=Iniciar sesión con Microsoft
-login.button.type.offline=Iniciar sin conexión
+login.button.type.offline=Iniciar sesión sin conexión
 login.label.username=Nombre de usuario
 login.dropdown.name=Usuarios Conectados
 login.button.play=Jugar
-login.button.logout=Cerrar Sesión
+login.button.logout=Cerrar sesión
 login.button.switch.offline=Cambiar a modo sin conexión
 login.button.switch.online=Cambiar a modo en línea
 
@@ -103,11 +103,11 @@ settings.option.theme.name=Tema
 settings.option.theme.light.name=Tema Claro
 settings.option.theme.dark.name=Tema Oscuro
 settings.option.theme.black.name=Tema Negro
-settings.option.sorting.name=Orden de las Instancias
-settings.option.sorting.bylastplayed.name=Ordenar Instancias por última vez jugada
-settings.option.sorting.byname.name=Ordenar Instancias por nombre
+settings.option.sorting.name=Orden de las instancias
+settings.option.sorting.bylastplayed.name=Ordenar instancias por última vez jugada
+settings.option.sorting.byname.name=Ordenar instancias por nombre
 settings.option.sorting.custom.name=Orden personalizado
-settings.option.default.name=Ocultar Instancias por Defecto
+settings.option.default.name=Ocultar instancias por Defecto
 settings.option.console.name=Mostrar Consola del Launcher
 settings.option.xmx.name=Permitir Argumentos Xmx
 settings.option.xmx.info=Usa esta opción si sabes lo que estás haciendo
@@ -122,29 +122,29 @@ settings.option.dgpu.info=Forzar el uso de la GPU dedicada en Windows
 settings.about.contributors=Gracias a todos los colaboradores:
 
 # Installations Manager
-manager.header.profiles=Instancias
-manager.header.modpacks=Paquetes de Mods
+manager.header.profiles=instancias
+manager.header.modpacks=Paquetes de mods
 manager.header.mods=Mods
-manager.header.resourcepacks=Paquetes de Recursos
+manager.header.resourcepacks=Paquetes de recursos
 manager.header.maps=Mapas
 manager.header.shaders=Shaders
 
-manager.button.new=Nueva Instancia
+manager.button.new=Nueva instancia
 manager.button.import=Importar modpack
 manager.profile.button.play=Jugar
 manager.profile.menu.edit=Editar
 manager.profile.menu.duplicate=Duplicar
 manager.profile.menu.delete=Eliminar
 
-manager.editor.header.title=Editar Instancia
+manager.editor.header.title=Editar instancia
 manager.editor.footer.button.save=Guardar
-manager.editor.option.name.name=Nombre de la Instancia
-manager.editor.option.name.placeholder=Instancia sin nombre
+manager.editor.option.name.name=Nombre de la instancia
+manager.editor.option.name.placeholder=instancia sin nombre
 manager.editor.option.version.name=Versión
 manager.editor.option.version.vanilla=Vanilla
 manager.editor.option.directory.name=Directorio del Juego
 manager.editor.option.directory.placeholder=Usar directorio por defecto
-manager.editor.option.directory.info.label=Algunos mods pueden requerir que la Instancia esté en la carpeta .minecraft. Para usar el directorio de juego .minecraft,
+manager.editor.option.directory.info.label=Algunos mods pueden requerir que la instancia esté en la carpeta .minecraft. Para usar el directorio de juego .minecraft,
 manager.editor.option.directory.info.link=haz clic aquí.
 
 manager.editor.button.more=Más Opciones
@@ -161,7 +161,7 @@ manager.editor.option.compatibility.info=Esta opción desactiva el sistema de sk
 manager.editor.option.visibility.name=Visibilidad del Launcher
 manager.editor.option.visibility.hide=Ocultar el launcher y reabrirlo cuando el juego se cierre
 manager.editor.option.visibility.close=Cerrar el launcher cuando el juego inicie
-manager.editor.option.visibility.keep=Mantener el launcher abierto
+manager.editor.option.visibility.keep=Mantener el launcher abierto y mostrar el juego
 manager.editor.option.visibility.keep.info=No se recomienda esta opción para computadoras de bajos recursos
 manager.editor.option.jvmpath.name=Ejecutable de Java
 manager.editor.option.jvmpath.placeholder=Usar el Java que viene incluido
@@ -184,11 +184,11 @@ manager.modpack.pagination.previous=Anterior
 manager.modpack.pagination.next=Siguiente
 
 # New Alerts
-alert.duplicate.window.title=Advertencia de Instancia Duplicada
+alert.duplicate.window.title=Advertencia de instancia Duplicada
 alert.duplicate.label.title=Ya tienes una instancia de Minecraft corriendo.
 alert.duplicate.label.body=Si inicias otra en el mismo directorio, podrían chocar y corromper tus mundos guardados. \nEsto podría causar muchos problemas, en un jugador o de otra forma. No nos hacemos responsables por nada que pueda salir mal. \n¿Quieres iniciar otra instancia de Minecraft, a pesar de esto? \nPuedes resolver este problema iniciando el juego en otro directorio (mira el botón "Editar instalación").
 
-alert.downgrade.window.title=Advertencia de Instancias Incompatibles
+alert.downgrade.window.title=Advertencia de instancias Incompatibles
 alert.downgrade.label.title=¿Restablecer instalaciones?
 alert.downgrade.label.body=¡Parece que has usado un launcher diferente a este! \nSi vuelves a usar este, necesitaremos restablecer tu configuración.
 alert.downgrade.button.reset=Estoy seguro. Restablecer mis ajustes


### PR DESCRIPTION
Chamo, pongan mi país

bro, put my country please

Le falta unas traducciones de latinoamericanos para este launcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Venezuelan Spanish (es-VE) language option with complete translations across the launcher UI — language selector, status labels, toggles, tabs, sidebar and button text, login and about screens, settings, update/crash dialogs, installation manager, project/modpack search and management, and warning/error prompts — improving accessibility and usability for Spanish (Venezuela) speakers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->